### PR TITLE
feat: upgrade to spring boot 2.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.jlmeek</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
 spring.datasource.password=sa
+spring.jpa.defer-datasource-initialization=true


### PR DESCRIPTION
Found a long-standing bug where one needed to add spring.jpa.defer-datasource-initialization: true to application.properties to actually load my test data. This was causing the tests to fail without a clear explanation. See https://www.baeldung.com/spring-boot-h2-database#2-hibernate-and-datasql